### PR TITLE
Unescape request url

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,6 @@
 require 'sinatra'
 require 'pdfkit'
+require 'uri'
 
 OPTS_PREFIX = 'WKHTMLTOPDF_OPTS_'
 WKHTMLTOPDF_OPTS = ENV.select{|k,_| k.start_with?(OPTS_PREFIX) }
@@ -24,7 +25,7 @@ def valid_url?(url)
 end
 
 def parse_reqest_url
-  request.env['REQUEST_URI'].split('/html2pdf/').last
+  URI.unescape(request.env['REQUEST_URI'].split('/html2pdf/').last)
 end
 
 put '/healthcheck' do


### PR DESCRIPTION
The HTTP client could remove consecutive slashes, so I would like to encode request url.

`/html2pdf/https://www. ` ---> `/html2pdf/https:/www.`